### PR TITLE
Remove quotes from redirect URI in env.bat

### DIFF
--- a/env.bat
+++ b/env.bat
@@ -4,7 +4,7 @@
 set SPOTIFY_USER_ID=<your_user_id>
 set SPOTIFY_CLIENT_ID=<your_client_id>
 set SPOTIFY_CLIENT_SECRET=<your_client_secret>
-set SPOTIFY_REDIRECT_URI="http://localhost:8888/callback"
+set SPOTIFY_REDIRECT_URI=http://localhost:8888/callback
 
 setx SPOTIFY_USER_ID %SPOTIFY_USER_ID%
 setx SPOTIFY_CLIENT_ID %SPOTIFY_CLIENT_ID%


### PR DESCRIPTION
Fixes issue #6 ‒ the quotes in the env variable get passed on to the generated URL, which looks like:
```
https://accounts.spotify.com/authorize?client_id=<client_id>&response_type=code&redirect_uri=%22http%3A%2F%2Flocalhost%3A8888%2Fcallback%22&scope=playlist-read-collaborative+playlist-modify-private+playlist-modify-public+playlist-read-private+ugc-image-upload
```
Notice the encoded quotes "" around the redirect URL ‒ this is invalid and results in an error.
Removing it from the env variable fixes it ‒ tested and verified on Windows.

(My editor also automatically fixed the missing line ending at the end of the file)