### PR TITLE
Continue transfering even with error

### DIFF
--- a/src/ytm2spt/gui.py
+++ b/src/ytm2spt/gui.py
@@ -358,7 +358,7 @@ class RunCommandWorker(QThread):
         except Exception as e:
             print(e)
             print(traceback.format_exc())
-            self.error.emit(str(e))
+            self.completed.emit()
 
 
 def main():


### PR DESCRIPTION
Just a propsal and can be solved in different ways

When running on very big playlists often error can occure because of connection or other random reasons. In my opinion it is more convenient to still move on with transfering even when some transfers failed and just display an error in console.